### PR TITLE
Fix using pyenv in powershell when pyenv-win path contains spaces

### DIFF
--- a/pyenv-win/bin/pyenv.bat
+++ b/pyenv-win/bin/pyenv.bat
@@ -134,16 +134,16 @@ rem TODO needed?
 call :normalizepath %exe% exe
 
 if exist "%exe%.bat" (
-  set "exe=call "%exe%.bat""
+  set exe=call "%exe%.bat"
 
 ) else if exist "%exe%.cmd" (
-  set "exe=call "%exe%.cmd""
+  set exe=call "%exe%.cmd"
 
 ) else if exist "%exe%.vbs" (
-  set "exe=cscript //nologo "%exe%.vbs""
+  set exe=cscript //nologo "%exe%.vbs"
 
 ) else if exist "%exe%.lnk" (
-  set "exe=start '' "%exe%.bat""
+  set exe=start '' "%exe%.bat"
 ) else (
   echo pyenv: no such command '%1'
   exit /b 1


### PR DESCRIPTION
## Issue:
Previously, after installing pyenv-win using git to a path containing spaces in the pathname, the invocation of pyenv commands in Powershell such as:
```powershell
"C:\Users\USER NAME WITH SPACES\.pyenv\pyenv-win\bin\..\libexec\pyenv.bat" install 3.11
```
or
```powershell
pyenv install 3.11
```

Were failing with an error message like:
```powershell
\.pyenv\pyenv-win\bin\..\libexec\pyenv-install.bat"" was unexpected at this time.
```

## Solution:
I updated `pyenv.bat` Windows batch file to properly concatenate the strings when setting the variables in the batch file.

Pyenv commands will now function properly from Powershell if the path to `.pyenv` contains spaces (e.g., Username contains spaces).

## Other Notes:
Also see pull request https://github.com/pyenv-win/pyenv-win/pull/618 and issue report https://github.com/pyenv-win/pyenv-win/issues/617 which mentions a similar issue. I personally did not have issues with installation (via git), but I did have problems executing the `pyenv-*.bat` files due to how string concatenation was previously handled.